### PR TITLE
FIX steam : On steam repo, the package for DEB is not steam-installer

### DIFF
--- a/registry/steam.toml
+++ b/registry/steam.toml
@@ -1,10 +1,10 @@
 [ubuntu]
 dependencies = ["apt-steam"]
-install_system = "steam-launcher"
+install_system = "steam"
 
 [debian]
 dependencies = ["apt-steam"]
-install_system = "steam-launcher"
+install_system = "steam"
 
 [arch]
 dependencies = ["arch-multilib"]


### PR DESCRIPTION
Error installing steam because steam-installer not avilable on ubuntu 25.10.
The package is in a non activated repo.
Because steam repo added, i switched with the package name used in steam repo.